### PR TITLE
Add option to use S3 Storage to back Harbor

### DIFF
--- a/REDACTED-params.yaml
+++ b/REDACTED-params.yaml
@@ -61,6 +61,14 @@ velero:
 harbor:
   harbor-cn: harbor.dorn.tkg-aws-e2-lab.winterfell.live
   notary-cn: notary.dorn.tkg-aws-e2-lab.winterfell.live
+#  blob-storage:
+#    type: s3 # Default is PVC, and can optionally be S3/MinIO
+#    regionendpoint: http://minio.server:9000 # Not required for AWS S3
+#    region: us-east-1
+#    access-key-id: REDACTED
+#    secret-access-key: REDACTED
+#    bucket: harbor-storage
+#    secure: false # set to true for HTTPS endpoints
 argocd:
   server-fqdn: argocd.dorn.tkg-aws-e2-lab.winterfell.live
   password: REDACTED

--- a/docs/bonus-labs/harbor.md
+++ b/docs/bonus-labs/harbor.md
@@ -9,6 +9,27 @@ harbor:
   notary-cn: notary.<shared-cluster domain name>
 ```
 
+#### S3 Backing for Harbor
+The default settings for Harbor use PVCs behind the registry and chartmuseum pods for blob storage.  Persistent Volume performance can be slow in home labs, or environments with poor storage or networking performance.  You can opt in to using S3 compatible storage as the backing for Harbor, and this can dramatically increase the performance in these environments.
+
+To use S3 blob storage for images and helm charts managed by Harbor, you can use the following settings in your params.yaml file:
+
+```yaml
+harbor:
+  harbor-cn: harbor.<shared-cluster domain name>
+  notary-cn: notary.<shared-cluster domain name>
+  blob-storage:
+    type: s3 # Default is PVC, and can optionally be S3/MinIO
+    region: us-east-1
+    regionendpoint: http://freenas.home:9000 # Not needed for AWS S3
+    access-key-id: minio
+    secret-access-key: minio1234
+    bucket: harbor-storage
+    secure: false # set to true for HTTPS endpoints/AWS S3
+```
+
+Since this storage is external to the process, you will need to clean it up if you decide to tear down your environment.
+
 ## Prepare Manifests and Deploy Harbor
 Harbor Registry should be installed in the shared services cluster, as it is going to be available to all users.  Prepare and deploy the YAML manifests for the related Harbor K8S objects.  Manifest will be output into `harbor/generated/` in case you want to inspect.
 

--- a/harbor/generate-and-apply-harbor-yaml.sh
+++ b/harbor/generate-and-apply-harbor-yaml.sh
@@ -33,6 +33,19 @@ yq write generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "expose.ingress.ho
 yq write generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "expose.ingress.hosts.notary" $NOTARY_CN  
 yq write generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "externalURL" https://$HARBOR_CN
 
+# Check for Blob storage type
+HARBOR_BLOB_STORAGE_TYPE=$(yq r $PARAMS_YAML harbor.blob-storage.type)
+if [ "s3" == "$HARBOR_BLOB_STORAGE_TYPE" ]; then
+  yq d generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "persistence.persistentVolumeClaim"
+  yq write generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "persistence.imageChartStorage.type" "s3"
+  yq write generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "persistence.imageChartStorage.s3.regionendpoint" "$(yq r $PARAMS_YAML harbor.blob-storage.regionendpoint)"
+  yq write generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "persistence.imageChartStorage.s3.region" "$(yq r $PARAMS_YAML harbor.blob-storage.region)"
+  yq write generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "persistence.imageChartStorage.s3.accesskey" "$(yq r $PARAMS_YAML harbor.blob-storage.access-key-id)"
+  yq write generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "persistence.imageChartStorage.s3.secretkey" "$(yq r $PARAMS_YAML harbor.blob-storage.secret-access-key)"
+  yq write generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "persistence.imageChartStorage.s3.bucket" "$(yq r $PARAMS_YAML harbor.blob-storage.bucket)"
+  yq write generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "persistence.imageChartStorage.s3.secure" "$(yq r $PARAMS_YAML harbor.blob-storage.secure)"
+fi
+
 helm repo add harbor https://helm.goharbor.io
 helm template harbor harbor/harbor -f generated/$CLUSTER_NAME/harbor/harbor-values.yaml --namespace harbor > generated/$CLUSTER_NAME/harbor/helm-manifest.yaml
 


### PR DESCRIPTION
PVC based storage for image and chart blobs can sometimes be a problem in smaller environments.  Using an external AWS S3, or MinIO based storage can speed up Harbor dramatically in these situations.  This PR adds the option to use S3 as the backing blob store for chartmuseum and registry in the Harbor chart.