### PR TITLE
Minor Editorial Refactors

### DIFF
--- a/harbor/harbor-values.yaml
+++ b/harbor/harbor-values.yaml
@@ -14,3 +14,5 @@ persistence:
   persistentVolumeClaim:
     registry:
       size: 30Gi
+clair:
+  enabled: false

--- a/scripts/generate-and-apply-external-dns-yaml.sh
+++ b/scripts/generate-and-apply-external-dns-yaml.sh
@@ -24,7 +24,7 @@ yq write generated/$CLUSTER_NAME/external-dns/values.yaml -i "aws.region" AWS_RE
 
 helm repo add bitnami https://charts.bitnami.com/bitnami
 
-helm upgrade --install external-dns bitnami/external-dns -n tanzu-system-ingress -f generated/dorn/external-dns/values.yaml
+helm upgrade --install external-dns bitnami/external-dns -n tanzu-system-ingress -f generated/$CLUSTER_NAME/external-dns/values.yaml
 
 #Wait for pod to be ready
 while kubectl get po -l app.kubernetes.io/name=external-dns -n tanzu-system-ingress | grep Running ; [ $? -ne 0 ]; do


### PR DESCRIPTION
Removes clair from harbor install as it deploys resources, but sits as a secondary scanner.  Might as well just have trivy which is running by default.

Also fixes an accidental hard code of a cluster name.