### PR TITLE
Enables Dex & Harbor to trust Let's Encrypt

### DIFF
--- a/overlay/overlay.yaml
+++ b/overlay/overlay.yaml
@@ -1,0 +1,26 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#! Add and trust the Let's Encrypt CA certificate authority in a given deployment
+#@overlay/match by=overlay.subset({"kind":"Deployment"}),expects="1+"
+---
+spec:
+  template:
+    spec:
+      volumes:
+      #@overlay/append
+      - name: letsencrypt
+        configMap:
+          name: #@ "{}-ca-cert".format(data.values.ca)
+          defaultMode: 420
+          items:
+          - key: ca.crt
+            path: #@ "{}.pem".format(data.values.ca)
+      containers:
+      #@overlay/match by=overlay.all,expects="1+"
+      #@overlay/match-child-defaults missing_ok=True
+      - volumeMounts:
+        #@overlay/append
+        - name: letsencrypt
+          mountPath: /etc/ssl/certs/letsencrypt.pem
+          subPath: #@ "{}.pem".format(data.values.ca)

--- a/overlay/trust-certificate/configmap.yaml
+++ b/overlay/trust-certificate/configmap.yaml
@@ -1,0 +1,12 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: #@ "{}-ca-cert".format(data.values.ca)
+  #@ if data.values.namespace:
+  namespace: #@ data.values.namespace
+  #@ end
+data:
+  ca.crt: #@ data.values.certificate
+  

--- a/overlay/trust-certificate/values.yaml
+++ b/overlay/trust-certificate/values.yaml
@@ -1,0 +1,5 @@
+#@data/values
+---
+ca:
+certificate:
+namespace:

--- a/scripts/generate-and-apply-dex-yaml.sh
+++ b/scripts/generate-and-apply-dex-yaml.sh
@@ -44,6 +44,8 @@ else
   sed -i -e 's/$OKTA_DEX_APP_CLIENT_SECRET/'$OKTA_DEX_APP_CLIENT_SECRET'/g' generated/$CLUSTER_NAME/dex/04-cm.yaml
 fi
 
+# add the letsencrypt certificate to the configmap as another entry
+yq write -d0 generated/$CLUSTER_NAME/dex/04-cm.yaml -i 'data."letsencrypt.pem"' -- "$(cat keys/letsencrypt-ca.pem)"
 
 kubectl apply -f tkg-extensions/authentication/dex/aws/oidc/01-namespace.yaml
 kubectl apply -f generated/$CLUSTER_NAME/dex/02-service.yaml
@@ -53,6 +55,10 @@ kubectl apply -f generated/$CLUSTER_NAME/dex/04-cm.yaml
 kubectl apply -f tkg-extensions/authentication/dex/aws/oidc/05-rbac.yaml
 
 # Same environment variables set previously
+if kubectl -n tanzu-system-auth get secret oidc ; then
+  kubectl -n tanzu-system-auth delete secret oidc 
+fi
+
 kubectl create secret generic oidc \
    --from-literal=clientId=$OKTA_DEX_APP_CLIENT_ID \
    --from-literal=clientSecret=$OKTA_DEX_APP_CLIENT_SECRET \
@@ -65,4 +71,10 @@ while kubectl get certificates -n tanzu-system-auth dex-cert | grep True ; [ $? 
 	sleep 5s
 done   
 
-kubectl apply -f tkg-extensions/authentication/dex/aws/oidc/06-deployment.yaml
+# inject the Let's Encrypt' ca cert as a trusted certificate
+ytt -f tkg-extensions/authentication/dex/aws/oidc/06-deployment.yaml -f overlay/trust-certificate --ignore-unknown-comments \
+    --data-value namespace=tanzu-system-auth \
+    --data-value certificate="$(cat keys/letsencrypt-ca.pem)" \
+    --data-value ca=letsencrypt > generated/$CLUSTER_NAME/dex/06-deployment.yaml
+ 
+kubectl apply -f generated/$CLUSTER_NAME/dex/06-deployment.yaml 


### PR DESCRIPTION
TL;DR
-----

Updates Dex and Harbor configurations so that deployed pods will
trust Let's Encrypt as a CA

Details
-------

Addreses a challenge I unearthed when using a custom URL (and thus
certificate) for my Okta endpoint. My custom endpoint uses a Let's
Encrypt certificate and the container images used by Dex and Harbor
do not include Let's Encrypt as a trusted certificate. This change
use a YTT overlay to both create a ConfigMap including the Let's
Encrypt CA cert and mount it as a volume so that OpenSSL will see
that certificate as a trusted one.