### PR TITLE
Applies external-dns annotation to envoy service via overlay on contour extension.

### DIFF
--- a/tkg-extensions-mods-examples/ingress/contour/contour-extension-overlay.yaml
+++ b/tkg-extensions-mods-examples/ingress/contour/contour-extension-overlay.yaml
@@ -1,0 +1,27 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:yaml", "yaml")
+#@ load("@ytt:data", "data")
+
+#@ def updates():
+spec:
+  fetch: 
+    #@overlay/append
+    - inline:
+        pathsFrom:
+          - configMapRef:
+              name: contour-overlay
+  template:
+    #@overlay/match by=overlay.all
+    - ytt:
+       #@overlay/replace
+       paths:
+         - 0/tkg-extensions/common
+         - 0/tkg-extensions/ingress/contour
+         - 1/contour-overlay.yaml
+#@ end
+
+#@overlay/match by=overlay.subset({"kind": "Extension"})
+---
+spec:
+  #@overlay/replace via=lambda a,_: yaml.encode(overlay.apply(yaml.decode(a), updates()))
+  objects:

--- a/tkg-extensions-mods-examples/ingress/contour/contour-overlay.yaml
+++ b/tkg-extensions-mods-examples/ingress/contour/contour-overlay.yaml
@@ -1,0 +1,12 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind":"Service", "metadata": {"name":"envoy"}}),expects="1+"
+---
+metadata:
+  annotations:
+    #@overlay/match missing_ok=True
+    tampered-by: tkg-lab
+    #@overlay/match missing_ok=True
+    external-dns.alpha.kubernetes.io/hostname: #@ data.values.tkg_lab.ingress_fqdn
+


### PR DESCRIPTION
Refactors the annotation on envoy so it is done declaratively via manifests instead of imperatively.