### PR TITLE
Enables Harbor to trust Let's Encrypt

### DIFF
--- a/scripts/generate-and-apply-harbor-yaml.sh
+++ b/scripts/generate-and-apply-harbor-yaml.sh
@@ -63,6 +63,7 @@ yq write -d0 generated/$SHAREDSVC_CLUSTER_NAME/harbor/harbor-data-values.yaml -i
 yq write -d0 generated/$SHAREDSVC_CLUSTER_NAME/harbor/harbor-data-values.yaml -i "tlsCertificate[tls.crt]" -- "$(< generated/$SHAREDSVC_CLUSTER_NAME/harbor/tls.crt)"
 yq write -d0 generated/$SHAREDSVC_CLUSTER_NAME/harbor/harbor-data-values.yaml -i "tlsCertificate[tls.key]" -- "$(< generated/$SHAREDSVC_CLUSTER_NAME/harbor/tls.key)"
 yq write -d0 generated/$SHAREDSVC_CLUSTER_NAME/harbor/harbor-data-values.yaml -i "tlsCertificate[ca.crt]" -- "$(< generated/$SHAREDSVC_CLUSTER_NAME/harbor/ca.crt)"
+yq write -d0 generated/$SHAREDSVC_CLUSTER_NAME/harbor/harbor-data-values.yaml -i "ca" "letsencrypt"
 # Check for Blob storage type
 HARBOR_BLOB_STORAGE_TYPE=$(yq r $PARAMS_YAML harbor.blob-storage.type)
 if [ "s3" == "$HARBOR_BLOB_STORAGE_TYPE" ]; then
@@ -88,10 +89,22 @@ else
 fi
 
 # Create a Kubernetes secret named harbor-data-values with the values that you set in harbor-data-values.yaml.
-kubectl create secret generic harbor-data-values --from-file=values.yaml=generated/$SHAREDSVC_CLUSTER_NAME/harbor/harbor-data-values.yaml -n tanzu-system-registry
+# Using the following "apply" syntax to allow for re-run
+kubectl create secret generic harbor-data-values -n tanzu-system-registry -o yaml --dry-run=client \
+  --from-file=values.yaml=generated/$SHAREDSVC_CLUSTER_NAME/harbor/harbor-data-values.yaml | kubectl apply -f -
 
+# Put the Let's Encrypt CA certificate into a configmap to add to trusted certifcates
+ytt -f overlay/trust-certificate/configmap.yaml -f overlay/trust-certificate/values.yaml --ignore-unknown-comments \
+  --data-value certificate="$(cat keys/letsencrypt-ca.pem)" \
+  --data-value ca=letsencrypt | kubectl apply -f - -n tanzu-system-registry
+
+# Add overlay to use let's encrypt cluster issuer and trust Let's Encrypt
+kubectl create configmap harbor-overlay -n tanzu-system-registry -o yaml --dry-run=client \
+  --from-file=overlay-s3-pvc-fix.yaml=tkg-extensions-mods-examples/registry/harbor/overlay-s3-pvc-fix.yaml \
+  --from-file=trust-letsencrypt.yaml=overlay/trust-certificate/overlay.yaml | kubectl apply -f-
+ 
 # Deploy the Harbor extension
-kubectl apply -f tkg-extensions/extensions/registry/harbor/harbor-extension.yaml
+kubectl apply -f tkg-extensions-mods-examples/registry/harbor/harbor-extension.yaml
 
 while kubectl get app harbor -n tanzu-system-registry | grep harbor | grep "Reconcile succeeded" ; [ $? -ne 0 ]; do
 	echo Harbor extension is not yet ready

--- a/tkg-extensions-mods-examples/registry/harbor/harbor-extension.yaml
+++ b/tkg-extensions-mods-examples/registry/harbor/harbor-extension.yaml
@@ -1,0 +1,46 @@
+apiVersion: clusters.tmc.cloud.vmware.com/v1alpha1
+kind: Extension
+metadata:
+  name: harbor
+  namespace: tanzu-system-registry
+  annotations:
+    tmc.cloud.vmware.com/managed: "false"
+spec:
+  description: harbor
+  version: "v2.0.2_vmware.1"
+  name: harbor
+  namespace: tanzu-system-registry
+  deploymentStrategy:
+    type: KUBERNETES_NATIVE
+  objects: |
+    apiVersion: kappctrl.k14s.io/v1alpha1
+    kind: App
+    metadata:
+      name: harbor
+      annotations:
+        tmc.cloud.vmware.com/orphan-resource: "true"
+    spec:
+      syncPeriod: 5m
+      serviceAccountName: harbor-extension-sa
+      fetch:
+        - image:
+            url: registry.tkg.vmware.run/tkg-extensions-templates:v1.2.0_vmware.1
+        - inline:
+            pathsFrom:
+              - configMapRef:
+                  name: harbor-overlay
+      template:
+        - ytt:
+            ignoreUnknownComments: true
+            paths:
+              - 0/tkg-extensions/common
+              - 0/tkg-extensions/registry/harbor
+              - 1/overlay-s3-pvc-fix.yaml
+              - 1/trust-letsencrypt.yaml
+            inline:
+              pathsFrom:
+                - secretRef:
+                    name: harbor-data-values
+      deploy:
+        - kapp:
+            rawOptions: ["--wait-timeout=5m"]

--- a/tkg-extensions-mods-examples/registry/harbor/overlay-s3-pvc-fix.yaml
+++ b/tkg-extensions-mods-examples/registry/harbor/overlay-s3-pvc-fix.yaml
@@ -1,0 +1,24 @@
+#@ load("/values.star", "values")
+#@ load("/kinds.lib.yaml", "kind_overlays")
+#@ load("@ytt:overlay", "overlay")
+
+#@ kind = kind_overlays
+#@ registry_metadata = overlay.subset({"metadata": {"name": "harbor-registry"}})
+
+#@ registry = values.persistence.persistentVolumeClaim.registry
+#@ storage = values.persistence.imageChartStorage
+
+#@ def pvc_required(x, y, z):
+#@  return not registry.existingClaim and storage.type == "filesystem"
+#@ end
+
+#@overlay/match by=overlay.and_op(overlay.and_op(kind.deployment, registry_metadata), overlay.not_op(pvc_required)),expects="0+"
+---
+spec:
+  template:
+    spec:
+      volumes:
+        #@overlay/match by="name"
+        #@overlay/replace 
+        - name: registry-data
+          emptyDir: {}


### PR DESCRIPTION
TL;DR
-----

Uses the trust certificate overlay to ensure that Harbor components
trust Let's Encrypt as a CA (fixes #120)

Details
-------

Allows using a custom URL/issuer for the Okta endpoint signed by
Let's Encrypt. Ran into the same issue with Harbor (#120) as with 
Dex whereby the OIDC integration would fail if the Okta endpoint 
was signed with Let's Encrypt (see #119 for that change). This 
change applies the overlay `overlay/trust-certificate` to the Harbor
extension to make sure the Let's Encrypt CA certificate is trusted
by all Harbor components.

As a bonus, while validating this change I found an issue where
the TKG extension for Harbor does not work when specifying an S3
backend. I added an additional overlay to make sure that works.