### PR TITLE
Using TAC app catalog for kubeapps

### DIFF
--- a/kubeapps/kubeapps-values.yaml
+++ b/kubeapps/kubeapps-values.yaml
@@ -4,7 +4,7 @@ allowNamespaceDiscovery: true
 ingress:
   enabled: true
   certManager: true
-  hostname: 
+  hostname:
   tls: true
   annotations:
     ingress.kubernetes.io/force-ssl-redirect: "true"
@@ -23,9 +23,8 @@ authProxy:
    #oauthLoginURI: /oauth2/start
    #oauthLogoutURI: /oauth2/sign_out
    additionalFlags:
-   
-   
-  
 
-
-
+apprepository:
+  initialRepos:
+    - name: tac-repo
+      url: https://charts.trials.tac.bitnami.com/demo


### PR DESCRIPTION
Using TAC app catalog for kubeapps. Using TAC app repository described [here](https://docs.bitnami.com/tanzu-application-catalog/get-started-tanzu-application-catalog/#consume-the-tac-artifacts-through-kubeapps) via helm configuration to avoid the manual steps.
Closes #121 