### PR TITLE
Allows for configurable k8s versions

### DIFF
--- a/REDACTED-params.yaml
+++ b/REDACTED-params.yaml
@@ -50,6 +50,7 @@ shared-services-cluster:
   controlplane-endpoint: 192.168.7.181 # only required for vsphere iaas
   metallb-start-ip: 192.168.7.210 # only required for vsphere iaas
   metallb-end-ip: 192.168.7.219 # only required for vsphere iaas
+  kubernetes-version: v1.19.1+vmware.2 # Explicitly set to v1.19.1 because v1.19.3 has an issue with TBS
 workload-cluster:
   worker-replicas: 2
   name: highgarden

--- a/docs/shared-services-cluster/01_install_tkg_ssc.md
+++ b/docs/shared-services-cluster/01_install_tkg_ssc.md
@@ -25,8 +25,11 @@ All of the steps above can be accomplished by running the following script:
 ./scripts/deploy-workload-cluster.sh \
   $(yq r $PARAMS_YAML shared-services-cluster.name) \
   $(yq r $PARAMS_YAML shared-services-cluster.worker-replicas) \
-  $(yq r $PARAMS_YAML shared-services-cluster.controlplane-endpoint)
+  $(yq r $PARAMS_YAML shared-services-cluster.controlplane-endpoint) \
+  $(yq r $PARAMS_YAML shared-services-cluster.kubernetes-version)
 ```
+
+>Note: The kuberentes-version parameter is optional for the script and if you don't have it in your configuration, then it will default to the default version of the TKG cli.
 
 >Note: Wait until your cluster has been created. It may take 12 minutes.
 

--- a/scripts/deploy-all-workload-cluster-components.sh
+++ b/scripts/deploy-all-workload-cluster-components.sh
@@ -7,7 +7,8 @@ source $TKG_LAB_SCRIPTS/set-env.sh
 $TKG_LAB_SCRIPTS/deploy-workload-cluster.sh \
   $(yq r $PARAMS_YAML workload-cluster.name) \
   $(yq r $PARAMS_YAML workload-cluster.worker-replicas) \
-  $(yq r $PARAMS_YAML workload-cluster.controlplane-endpoint)
+  $(yq r $PARAMS_YAML workload-cluster.controlplane-endpoint) \
+  $(yq r $PARAMS_YAML workload-cluster.kuberentes-version)
 # Workload Step 2
 $TKG_LAB_SCRIPTS/tmc-attach.sh $(yq r $PARAMS_YAML workload-cluster.name)
 # Workload Step 3

--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -41,7 +41,8 @@ $TKG_LAB_SCRIPTS/deploy-wavefront.sh $(yq r $PARAMS_YAML management-cluster.name
 $TKG_LAB_SCRIPTS/deploy-workload-cluster.sh \
   $(yq r $PARAMS_YAML shared-services-cluster.name) \
   $(yq r $PARAMS_YAML shared-services-cluster.worker-replicas) \
-  $(yq r $PARAMS_YAML shared-services-cluster.controlplane-endpoint)
+  $(yq r $PARAMS_YAML shared-services-cluster.controlplane-endpoint) \
+  $(yq r $PARAMS_YAML shared-services-cluster.kuberentes-version)
 # Shared Services Step 2
 $TKG_LAB_SCRIPTS/tmc-attach.sh $(yq r $PARAMS_YAML shared-services-cluster.name)
 # Shared Services Step 3


### PR DESCRIPTION
Suggests in redacted perams.yaml to set shared services version to v1.19.1 to work around TBS issue with containerd version in v1.19.3.