### PR TITLE
adding new post deploy script and few other tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ local-config/*
 crashd/*
 !crashd/.gitkeep
 tkg-mgmt.diagnostics.tar.gz
+tkg-extensions-manifests*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ crashd/*
 !crashd/.gitkeep
 tkg-mgmt.diagnostics.tar.gz
 tkg-extensions-manifests*.tar.gz
+.envrc

--- a/docs/shared-services-cluster/01_install_tkg_ssc.md
+++ b/docs/shared-services-cluster/01_install_tkg_ssc.md
@@ -36,6 +36,15 @@ All of the steps above can be accomplished by running the following script:
 
 >Note: You can view the cluster-config.yaml file generated for this cluster at `generated/$CLUSTER_NAME/cluster-config.yaml`.
 
+## Post Deployment Configuration
+
+At this point the shared services cluster is deployed. We will be capturing the kubeconfig for the shared services cluster and adding a few additional components. The following script will perform these actions.
+
+```bash
+./scripts/post-deploy-cluster.sh \
+  $(yq e .shared-services-cluster.name $PARAMS_YAML) \
+```
+
 ## Go to Next Step
 
 [Attach Shared Services Cluster to TMC](02_attach_tmc_ssc.md)

--- a/scripts/01-prep-aws-objects.sh
+++ b/scripts/01-prep-aws-objects.sh
@@ -7,7 +7,7 @@ export AWS_REGION=$(yq e .aws.region $PARAMS_YAML)
 export AWS_ACCESS_KEY_ID=$(yq e .aws.access-key-id $PARAMS_YAML)
 export AWS_SECRET_ACCESS_KEY=$(yq e .aws.secret-access-key $PARAMS_YAML)
 
-tanzu management-cluster permissions aws set
+#tanzu management-cluster permissions aws set
 
 TKG_ENVIRONMENT_NAME=$(yq e .environment-name $PARAMS_YAML)
 SSH_KEY_FILE_NAME=$TKG_ENVIRONMENT_NAME-ssh.pem

--- a/scripts/post-deploy-cluster.sh
+++ b/scripts/post-deploy-cluster.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+TKG_LAB_SCRIPTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $TKG_LAB_SCRIPTS/set-env.sh
+
+CLUSTER_NAME=$1
+IAAS=$(yq e .iaas $PARAMS_YAML)
+
+tanzu cluster kubeconfig get $CLUSTER_NAME --admin
+
+kubectl config use-context $CLUSTER_NAME-admin@$CLUSTER_NAME
+
+# We have found that after the tanzu cli reports that the managmement cluster is created, there are additional initialation of system pods.  In order 
+# to ensure that the cluster is fully initilized, we will wait for the pinniped-supervisor job to be completed.
+while kubectl get po -n pinniped-supervisor | grep Completed ; [ $? -ne 0 ]; do
+	echo "Pinniped Configuration is not yet complete"
+	sleep 5s
+done
+
+kubectl apply -f tkg-extensions-mods-examples/tanzu-kapp-namespace.yaml
+kubectl apply -f storage-classes/default-storage-class-$IAAS.yaml


### PR DESCRIPTION
- was an error that tanzu-kapp namespace not found when deploying contour in shared services workflow.  I added a post-deploy-cluster.sh that mimics the post-deploy-management-cluster script capturing kubeconfig and installs kapp
- updated README to include above step
- added a few things to gitignore