### PR TITLE
aws machine types now selectable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ keys/*
 config.yaml
 .secrets
 tkg-extensions
+tkg-extensions-manifests*.gz
 acme_fitness_demo
 tmc.token
 sensitive/
@@ -14,3 +15,4 @@ local-config/*
 crashd/*
 !crashd/.gitkeep
 tkg-mgmt.diagnostics.tar.gz
+.envrc

--- a/REDACTED-params.yaml
+++ b/REDACTED-params.yaml
@@ -16,6 +16,8 @@ aws:
   access-key-id: REDACTED
   secret-access-key: REDACTED
   hosted-zone-id: Z00636703RP40GVIAWHLA # clear this value out to start, and script will generate a new zone for you
+  control-plane-machine-type: c5.xlarge # eg. c5.xlarge or m4.xlarge
+  node-machine-type: c5.xlarge # eg. c5.xlarge or m4.xlarge
 azure:
   environment: "AzurePublicCloud" # NOTE: Always "AzurePublicCloud"
   location: # eg. canadacentral.  az account list-locations -o table

--- a/config-templates/aws-cluster-config.yaml
+++ b/config-templates/aws-cluster-config.yaml
@@ -8,8 +8,8 @@ WORKER_MACHINE_COUNT: # Added by scripts
 
 INFRASTRUCTURE_PROVIDER: aws
 CLUSTER_PLAN: dev # default is blank
-CONTROL_PLANE_MACHINE_TYPE: c5.xlarge # t3.large
-NODE_MACHINE_TYPE: c5.xlarge # t3.xlarge
+CONTROL_PLANE_MACHINE_TYPE: # Added by scripts
+NODE_MACHINE_TYPE: # Added by scripts
 
 TKG_HTTP_PROXY_ENABLED: "false" # default is blank
 ENABLE_MHC: "true" # default is blank

--- a/docs/mgmt-cluster/01_install_tkg_mgmt.md
+++ b/docs/mgmt-cluster/01_install_tkg_mgmt.md
@@ -23,7 +23,7 @@ In order to do the steps above in a scripted manner, you simply need to ensure y
 ./scripts/01-prep-aws-objects.sh
 ```
 
-2. The documentation to [Deploy the Management Cluster to Amazon EC2 with the CLI](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.3/vmware-tanzu-kubernetes-grid-13/GUID-mgmt-clusters-aws-cli.html) explains that the `tanzu management-cluster create` cli command requires a configuration file that identifies the configuration values for your management cluster.  The script below will copy a template configuration file for AWS from this lab, and then replace the values with the specific configuration found in your `$PARAMS_YAML` file. Run this script to complete the deployment.
+2. The documentation to [Deploy the Management Cluster to Amazon EC2 with the CLI](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.3/vmware-tanzu-kubernetes-grid-13/GUID-mgmt-clusters-aws-cli.html) explains that the `tanzu management-cluster create` cli command requires a configuration file that identifies the configuration values for your management cluster.  While sane defaults have been chosen, make sure Tanzu supported machine types are selected to match those available in the region selected.  The tanzu UI displays the canonical list of supported machine types.  The script below will copy a template configuration file for AWS from this lab, and then replace the values with the specific configuration found in your `$PARAMS_YAML` file. Run this script to complete the deployment.
 
 ```bash
 ./scripts/02-deploy-aws-mgmt-cluster.sh

--- a/docs/mgmt-cluster/01_install_tkg_mgmt.md
+++ b/docs/mgmt-cluster/01_install_tkg_mgmt.md
@@ -118,7 +118,7 @@ Deploying management clusters in various IaaS takes anywhere from 10-25 minutes.
 2. Validation Step. Check management cluster is provisioned, pods are running:
 
 ```bash
-tkg get management-clusters
+tanzu cluster list --include-management-cluster
 kubectl get pods -A
 ```
 

--- a/docs/shared-services-cluster/10_harbor.md
+++ b/docs/shared-services-cluster/10_harbor.md
@@ -102,7 +102,13 @@ okta:
 echo "https://$(yq e .okta.auth-server-fqdn $PARAMS_YAML)/oauth2/default"
 ```
   - OIDC Client ID: <okta.harbor-app-client-id from $PARAMS_YAML>
+```bash
+echo "$(yq e .okta.harbor-app-client-id $PARAMS_YAML)"
+```
   - OIDC Client Secret: <okta.harbor-app-client-secret from $PARAMS_YAML>
+```bash
+echo "$(yq e .okta.harbor-app-client-secret $PARAMS_YAML)"
+```
   - Group Claim Name: `groups`
   - OIDC Scope: `openid,profile,email,groups,offline_access`
   - Verify Certificate: `checked`

--- a/docs/shared-services-cluster/10_harbor.md
+++ b/docs/shared-services-cluster/10_harbor.md
@@ -66,7 +66,13 @@ open https://$(yq e .harbor.harbor-cn $PARAMS_YAML)
   - Give your app a name: `Harbor`
   - For Grant type, check Authorization Code and Refresh Token
   - Sign-in redirect URIs: `https://<harbor.harbor-cn from $PARAMS_YAML>/c/oidc/callback` #
+```bash
+echo "https://$(yq e .harbor.harbor-cn $PARAMS_YAML)/c/oidc/callback"
+```
   - Sign-out redirect URIs: `https://<harbor.harbor-cn from $PARAMS_YAML>/c/oidc/logout`
+```bash
+echo "https://$(yq e .harbor.harbor-cn $PARAMS_YAML)/c/oidc/logout"
+```
 
 3. Capture `Client ID` and `Client Secret` for and put it in your $PARAMS_YAML file.
 
@@ -92,6 +98,9 @@ okta:
   - Auth Mode: `OIDC`
   - OIDC Provider Name: `Okta`
   - OIDC Endpoint: `https://<okta.auth-server-fqdn from $PARAMS_YAML>/oauth2/default`
+```bash
+echo "https://$(yq e .okta.auth-server-fqdn $PARAMS_YAML)/oauth2/default"
+```
   - OIDC Client ID: <okta.harbor-app-client-id from $PARAMS_YAML>
   - OIDC Client Secret: <okta.harbor-app-client-secret from $PARAMS_YAML>
   - Group Claim Name: `groups`

--- a/scripts/02-deploy-aws-mgmt-cluster.sh
+++ b/scripts/02-deploy-aws-mgmt-cluster.sh
@@ -14,6 +14,8 @@ export OIDC_ISSUER_URL=https://$(yq e .okta.auth-server-fqdn $PARAMS_YAML)
 export OIDC_CLIENT_ID=$(yq e .okta.tkg-app-client-id $PARAMS_YAML)
 export OIDC_CLIENT_SECRET=$(yq e .okta.tkg-app-client-secret $PARAMS_YAML)
 export WORKER_REPLICAS=$(yq e .management-cluster.worker-replicas $PARAMS_YAML)
+export AWS_CONTROL_PLANE_MACHINE_TYPE=$(yq e .aws.control-plane-machine-type $PARAMS_YAML)
+export AWS_NODE_MACHINE_TYPE=$(yq e .aws.node-machine-type $PARAMS_YAML)
 
 yq e -i '.CLUSTER_NAME = env(CLUSTER)' generated/$CLUSTER/cluster-config.yaml
 yq e -i '.AWS_REGION = env(REGION)' generated/$CLUSTER/cluster-config.yaml
@@ -22,5 +24,7 @@ yq e -i '.OIDC_IDENTITY_PROVIDER_ISSUER_URL = env(OIDC_ISSUER_URL)' generated/$C
 yq e -i '.OIDC_IDENTITY_PROVIDER_CLIENT_ID = env(OIDC_CLIENT_ID)' generated/$CLUSTER/cluster-config.yaml
 yq e -i '.OIDC_IDENTITY_PROVIDER_CLIENT_SECRET = env(OIDC_CLIENT_SECRET)' generated/$CLUSTER/cluster-config.yaml
 yq e -i '.WORKER_MACHINE_COUNT = env(WORKER_REPLICAS)' generated/$CLUSTER/cluster-config.yaml
+yq e -i '.CONTROL_PLANE_MACHINE_TYPE = env(AWS_CONTROL_PLANE_MACHINE_TYPE)' generated/$CLUSTER/cluster-config.yaml
+yq e -i '.NODE_MACHINE_TYPE = env(AWS_NODE_MACHINE_TYPE)' generated/$CLUSTER/cluster-config.yaml
 
 tanzu management-cluster create --file=generated/$CLUSTER/cluster-config.yaml -v 6


### PR DESCRIPTION
I kept those previous changes to .gitignore
made the aws machine types modifiable in params
updated the README with verbiage pointing them to tanzu --ui as canonical list of machine types per region

my test deploy is still provisioning, but it looks like it'll all work... submitting now so I don't forget