### PR TITLE
Updates URL for lets encrypt CA

### DIFF
--- a/scripts/retrieve-lets-encrypt-ca-cert.sh
+++ b/scripts/retrieve-lets-encrypt-ca-cert.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
 
-curl https://letsencrypt.org/certs/lets-encrypt-r3-cross-signed.pem -o keys/letsencrypt-ca.pem
+curl https://letsencrypt.org/certs/isrg-root-x1-cross-signed.pem -o keys/letsencrypt-ca.pem
      
 chmod 600 keys/letsencrypt-ca.pem


### PR DESCRIPTION
Addresses https://techcrunch.com/2021/09/21/lets-encrypt-root-expiry/